### PR TITLE
fix: Remove unnecessary import and raise maxOutputTokens

### DIFF
--- a/app/src/main/java/gemini/workshop/TemplatePrompt.java
+++ b/app/src/main/java/gemini/workshop/TemplatePrompt.java
@@ -20,7 +20,6 @@ import dev.langchain4j.model.input.PromptTemplate;
 import dev.langchain4j.model.vertexai.VertexAiGeminiChatModel;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.input.Prompt;
-import dev.langchain4j.model.input.PromptTemplate;
 import dev.langchain4j.model.output.Response;
 
 import java.util.HashMap;
@@ -32,7 +31,7 @@ public class TemplatePrompt {
             .project(System.getenv("PROJECT_ID"))
             .location(System.getenv("LOCATION"))
             .modelName("gemini-2.0-flash")
-            .maxOutputTokens(500)
+            .maxOutputTokens(4000)
             .temperature(1.0f)
             .topK(40)
             .topP(0.95f)


### PR DESCRIPTION
Too low maxOutputTokens is causing the recipe to be cut instead of showing the whole thing.